### PR TITLE
Add sorting to sessions comparison

### DIFF
--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -76,14 +76,19 @@ impl Sessions {
 
     #[cfg(debug_assertions)]
     pub(crate) fn equals_test_only(&self, other: &Sessions) -> bool {
-        let mut filtered_a = self
-            .session_list
-            .iter()
-            .filter(|&session_space| session_space.cluster_chain.len() > 0);
-        let mut filtered_b = other
-            .session_list
-            .iter()
-            .filter(|&session_space| session_space.cluster_chain.len() > 0);
+        fn get_sorted_sessions(session_space: &Sessions) -> impl Iterator<Item = &SessionSpace> {
+            let mut filtered: Vec<&SessionSpace> = session_space
+                .session_list
+                .iter()
+                .filter(|&session_space| session_space.cluster_chain.len() > 0)
+                .collect();
+            filtered.sort_by(|session_space_a, session_space_b| {
+                session_space_a.session_id.cmp(&session_space_b.session_id)
+            });
+            filtered.into_iter()
+        }
+        let mut filtered_a = get_sorted_sessions(self);
+        let mut filtered_b = get_sorted_sessions(other);
         loop {
             let session_space_a = filtered_a.next();
             let session_space_b = filtered_b.next();

--- a/rust-wasm-id-allocator/id-types/src/session_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_id.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use super::StableId;
 use crate::LocalId;
 
-#[derive(Eq, PartialEq, Hash, Copy, Clone, Debug)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]
 pub struct SessionId {
     id: StableId,
 }


### PR DESCRIPTION
Handles cases of multiple rounds of serialization and deserialization where new session adds a local session to the session list, making it impossible to rely on ordering without sorting.