### PR TITLE
Use AVL tree instead of btree

### DIFF
--- a/rust-wasm-id-allocator/Cargo.lock
+++ b/rust-wasm-id-allocator/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "avl"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1249cb3effef43713024f23137529eb78c42bf288e7c60475b479f2e63f7379e"
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +57,7 @@ checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 name = "distributed-id-allocator"
 version = "0.1.0"
 dependencies = [
+ "avl",
  "id-types",
  "postcard",
  "serde",

--- a/rust-wasm-id-allocator/distributed-id-allocator/Cargo.toml
+++ b/rust-wasm-id-allocator/distributed-id-allocator/Cargo.toml
@@ -24,3 +24,4 @@ features = [
 
 [dependencies]
 id-types = { path = "../../rust-wasm-id-allocator/id-types", version = "0.1", default-features = false }
+avl = "0.7.1"

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -2,22 +2,22 @@
 The local/UUID space within an individual Session.
 Effectively represents the cluster chain for a given session.
 */
+use avl::AvlTreeMap;
 use id_types::session_id::from_stable_id;
 use id_types::{FinalId, LocalId, SessionId, StableId};
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
 use std::ops::Bound;
 
 #[derive(Debug)]
 pub struct Sessions {
-    session_map: BTreeMap<SessionId, SessionSpaceRef>,
+    session_map: AvlTreeMap<SessionId, SessionSpaceRef>,
     session_list: Vec<SessionSpace>,
 }
 
 impl Sessions {
     pub fn new() -> Sessions {
         Sessions {
-            session_map: BTreeMap::new(),
+            session_map: AvlTreeMap::new(),
             session_list: Vec::new(),
         }
     }


### PR DESCRIPTION
2x speedup on deserialization, ~2KB off gzipped size