### PR TITLE
Remove fmt dependency from codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ To build the Rust workspace, run `cargo build` from the rust-wasm-id-allocator f
 
 ## TypeScript
 
+In order to build, you must have _wasm-snip_ installed (`cargo install wasm-snip`).
+
 - Debug
   - To build the TS/WASM package for debugging, run `npm run build` from the typescript-id-allocator folder.
 - Benchmarking

--- a/rust-wasm-id-allocator/Cargo.toml
+++ b/rust-wasm-id-allocator/Cargo.toml
@@ -2,6 +2,7 @@
 members = ["./distributed-id-allocator", "./wasm-id-allocator", "./id-types"]
 
 [profile.release]
+debug = true
 opt-level = 2
 lto = true
 codegen-units = 1

--- a/rust-wasm-id-allocator/id-types/src/session_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_id.rs
@@ -45,11 +45,6 @@ impl SessionId {
     pub fn from_uuid_u128(uuid_u128: u128) -> SessionId {
         uuid::Builder::from_u128(uuid_u128).into_uuid().into()
     }
-
-    /// Returns the SessionId as a hyphenated UUID string.
-    pub fn to_uuid_string(&self) -> String {
-        Uuid::from(self.id).to_string()
-    }
 }
 
 impl From<Uuid> for SessionId {

--- a/rust-wasm-id-allocator/id-types/src/stable_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/stable_id.rs
@@ -28,11 +28,11 @@ const STRIPPED_MIDDIE_BITTIES_MASK: u128 = MIDDIE_BITTIES_MASK >> 2;
 // The more-significant half of the N nibble is used to denote the variant (10xx)
 const LOWER_MASK: u128 = 0x3FFFFFFFFFFFFFFF;
 
-impl From<StableId> for [u8; 36] {
+impl From<StableId> for Vec<u8> {
     fn from(id: StableId) -> Self {
         let mut uuid_arr: [u8; 36] = [b'0'; 36];
         _ = Uuid::from(id).as_hyphenated().encode_lower(&mut uuid_arr);
-        uuid_arr
+        Vec::from(uuid_arr)
     }
 }
 

--- a/rust-wasm-id-allocator/wasm-id-allocator/Cargo.toml
+++ b/rust-wasm-id-allocator/wasm-id-allocator/Cargo.toml
@@ -21,7 +21,7 @@ features = [
 ]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O2", "--enable-mutable-globals"]
+wasm-opt = false
 
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 debug-js-glue = false

--- a/rust-wasm-id-allocator/wasm-id-allocator/src/lib.rs
+++ b/rust-wasm-id-allocator/wasm-id-allocator/src/lib.rs
@@ -74,7 +74,8 @@ impl IdCompressor {
         })
     }
 
-    /// Returns the local session ID as a UUID string.
+    /// Returns the local session ID UUID.
+    /// For interop performance, this method returns a byte array containing the ASCII representation of the UUID string.
     /// Should not be called frequently due to marshalling costs.
     pub fn get_local_session_id(&self) -> Vec<u8> {
         Vec::from(StableId::from(self.compressor.get_local_session_id()))

--- a/typescript-id-allocator/package-lock.json
+++ b/typescript-id-allocator/package-lock.json
@@ -24,6 +24,7 @@
 				"rimraf": "^3.0.2",
 				"ts-node": "^10.9.1",
 				"typescript": "^4.8.3",
+				"wasm-opt": "^1.4.0",
 				"wasm-pack": "^0.10.3"
 			}
 		},
@@ -2002,6 +2003,40 @@
 		"node_modules/wasm-id-allocator": {
 			"resolved": "dist/wasm",
 			"link": true
+		},
+		"node_modules/wasm-opt": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/wasm-opt/-/wasm-opt-1.4.0.tgz",
+			"integrity": "sha512-wIsxxp0/FOSphokH4VOONy1zPkVREQfALN+/JTvJPK8gFSKbsmrcfECu2hT7OowqPfb4WEMSMceHgNL0ipFRyw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-fetch": "^2.6.9",
+				"tar": "^6.1.13"
+			},
+			"bin": {
+				"wasm-opt": "bin/wasm-opt.js"
+			}
+		},
+		"node_modules/wasm-opt/node_modules/node-fetch": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+			"integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/wasm-pack": {
 			"version": "0.10.3",

--- a/typescript-id-allocator/package.json
+++ b/typescript-id-allocator/package.json
@@ -1,10 +1,12 @@
 {
 	"scripts": {
-		"build": "npm run build:wasm && npm run build:ts",
-		"build:release": "npm run build:wasm-release && npm run build:ts",
+		"build": "npm run build:wasm && npm run build:snip && npm run build:ts",
+		"build:release": "npm run build:wasm-release && npm run build:snip && npm run build:opt && npm run build:ts",
 		"build:ts": "npm i && tsc --project \"tsconfig.json\"",
 		"build:wasm": "npm i --only=dev && wasm-pack build --debug --target nodejs --out-dir ../../typescript-id-allocator/dist/wasm ../rust-wasm-id-allocator/wasm-id-allocator",
 		"build:wasm-release": "npm i --only=dev && wasm-pack build --target nodejs --out-dir ../../typescript-id-allocator/dist/wasm ../rust-wasm-id-allocator/wasm-id-allocator",
+		"build:snip": "wasm-snip ./dist/wasm/wasm_id_allocator_bg.wasm --snip-rust-fmt-code --snip-rust-panicking-code -o ./dist/wasm/wasm_id_allocator_bg.wasm",
+		"build:opt": "wasm-opt -O2 --enable-mutable-globals -o dist/wasm/wasm_id_allocator_bg.wasm dist/wasm/wasm_id_allocator_bg.wasm",
 		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js ./dist/**/*.spec.js",
 		"clean": "rimraf ./dist",
 		"test": "npm run build:ts && mocha ./dist/javascript/test/**/*.js --recursive",
@@ -25,6 +27,7 @@
 		"rimraf": "^3.0.2",
 		"ts-node": "^10.9.1",
 		"typescript": "^4.8.3",
+		"wasm-opt": "^1.4.0",
 		"wasm-pack": "^0.10.3"
 	},
 	"dependencies": {

--- a/typescript-id-allocator/src/util/utilities.ts
+++ b/typescript-id-allocator/src/util/utilities.ts
@@ -141,3 +141,14 @@ export function fail(message: string): never {
 export function isNaN(num: any): boolean {
 	return Object.is(num, Number.NaN);
 }
+
+export function uuidStringFromBytes(uuidBytes: Uint8Array | undefined): string | undefined {
+	if (uuidBytes === undefined) {
+		return undefined;
+	}
+	let uuidString = "";
+	for (let i = 0; i < 36; i++) {
+		uuidString += String.fromCharCode(uuidBytes[i]);
+	}
+	return uuidString;
+}

--- a/typescript-id-allocator/test/id-compressor/testCommon.ts
+++ b/typescript-id-allocator/test/id-compressor/testCommon.ts
@@ -6,6 +6,7 @@
 import { TestOnly } from "wasm-id-allocator";
 import { IdCompressor } from "../../src/IdCompressor";
 import { SessionSpaceCompressedId, StableId, OpSpaceCompressedId } from "../../src/types";
+import { uuidStringFromBytes } from "../../src/util/utilities";
 
 /**
  * An identifier (v4 UUID) that has been shortened by a distributed compression algorithm.
@@ -76,7 +77,7 @@ export function getOrCreate<K, V>(map: Map<K, V>, key: K, defaultValue: (key: K)
 }
 
 export function incrementStableId(stableId: StableId, offset: number): StableId {
-	return TestOnly.increment_uuid(stableId, offset) as StableId;
+	return uuidStringFromBytes(TestOnly.increment_uuid(stableId, offset)) as StableId;
 }
 
 /**


### PR DESCRIPTION
~16% reduction in binary size
Removed all dependencies on string formatting (accidental default to_string), and wasm-snipped out all fmt/panic code.

Introduces a dependency that the code owner have wasm-snip installed (`cargo install wasm-snip`).