### PR TITLE
Serialization optimization

### DIFF
--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor.rs
@@ -479,11 +479,7 @@ impl IdCompressor {
                             }
                         }
 
-                        Ok(self
-                            .sessions
-                            .deref_session_space(containing_session_space)
-                            .session_id()
-                            + aligned_local)
+                        Ok(self.sessions.get_session_id(containing_session_space) + aligned_local)
                     }
                     None => Err(AllocatorError::InvalidSessionSpaceId),
                 }

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
@@ -90,11 +90,7 @@ pub mod v1 {
         write_u64_to_vec(bytes, compressor.cluster_capacity);
         write_u64_to_vec(bytes, compressor.sessions.get_session_count() as u64);
 
-        compressor
-            .sessions
-            .get_session_spaces()
-            .map(|session_space| StableId::from(session_space.session_id()).into())
-            .for_each(|session_u128| write_u128_to_vec(bytes, session_u128));
+        bytes.extend_from_slice(compressor.sessions.get_session_id_slice());
 
         write_u64_to_vec(bytes, compressor.final_space.get_cluster_count() as u64);
         compressor
@@ -136,7 +132,7 @@ pub mod v1 {
         let mut session_ref_remap = Vec::new();
         for _ in 0..session_count {
             let session_uuid_u128 = deserializer.take_u128();
-            let session_id = SessionId::from_uuid_u128(session_uuid_u128);
+            let session_id = SessionId::from_id_u128(session_uuid_u128);
             if !with_local_state && session_id == compressor.session_id {
                 return Err(DeserializationError::InvalidResumedSession);
             }

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
@@ -50,7 +50,10 @@ pub mod v1 {
             },
         },
     };
-    use id_types::{FinalId, LocalId, SessionId, StableId};
+    use id_types::{
+        session_id::{session_id_from_id_u128, session_id_from_uuid_u128},
+        FinalId, LocalId, SessionId, StableId,
+    };
 
     // Layout
     // has_local_state: bool as u64
@@ -119,7 +122,7 @@ pub mod v1 {
             true => {
                 let session_uuid_u128 = deserializer.take_u128();
                 let mut compressor =
-                    IdCompressor::new_with_session_id(SessionId::from_uuid_u128(session_uuid_u128));
+                    IdCompressor::new_with_session_id(session_id_from_uuid_u128(session_uuid_u128));
                 compressor.generated_id_count = deserializer.take_u64();
                 compressor.next_range_base_generation_count = deserializer.take_u64();
                 compressor.session_space_normalizer = deserialize_normalizer(deserializer);
@@ -132,7 +135,7 @@ pub mod v1 {
         let mut session_ref_remap = Vec::new();
         for _ in 0..session_count {
             let session_uuid_u128 = deserializer.take_u128();
-            let session_id = SessionId::from_id_u128(session_uuid_u128);
+            let session_id = session_id_from_id_u128(session_uuid_u128);
             if !with_local_state && session_id == compressor.session_id {
                 return Err(DeserializationError::InvalidResumedSession);
             }

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
@@ -23,10 +23,9 @@ impl<'a> Deserializer<'a> {
         if SIZE > self.bytes.len() {
             panic!()
         }
-        let mut val_arr: [u8; SIZE] = [0; SIZE];
-        val_arr[..SIZE].copy_from_slice(&self.bytes[..SIZE]);
+        let val = builder(self.bytes[..SIZE].try_into().unwrap());
         self.bytes = &self.bytes[SIZE..];
-        builder(val_arr)
+        val
     }
 }
 
@@ -35,9 +34,7 @@ where
     FToBytes: Fn(T) -> [u8; SIZE],
 {
     let val_arr = builder(val);
-    for byte in val_arr {
-        bytes.push(byte);
-    }
+    bytes.extend_from_slice(&val_arr);
 }
 
 #[inline]

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
@@ -20,9 +20,6 @@ impl<'a> Deserializer<'a> {
     where
         FBuild: Fn([u8; SIZE]) -> T,
     {
-        if SIZE > self.bytes.len() {
-            panic!()
-        }
         let val = builder(self.bytes[..SIZE].try_into().unwrap());
         self.bytes = &self.bytes[SIZE..];
         val

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
@@ -8,14 +8,31 @@ impl<'a> Deserializer<'a> {
     }
 
     pub fn take_u64(&mut self) -> u64 {
+        #[cfg(target_endian = "little")]
+        {
+            let ptr = std::ptr::addr_of!(self.bytes[0]) as *const u64;
+            let val = unsafe { std::ptr::read_unaligned(ptr) };
+            self.bytes = &self.bytes[8..];
+            val
+        }
+        #[cfg(not(target_endian = "little"))]
         self.take_one(u64::from_le_bytes)
     }
 
     pub fn take_u128(&mut self) -> u128 {
+        #[cfg(target_endian = "little")]
+        {
+            let ptr = std::ptr::addr_of!(self.bytes[0]) as *const u128;
+            let val = unsafe { std::ptr::read_unaligned(ptr) };
+            self.bytes = &self.bytes[16..];
+            val
+        }
+        #[cfg(not(target_endian = "little"))]
         self.take_one(u128::from_le_bytes)
     }
 
     #[inline]
+    #[cfg(not(target_endian = "little"))]
     fn take_one<FBuild, T, const SIZE: usize>(&mut self, builder: FBuild) -> T
     where
         FBuild: Fn([u8; SIZE]) -> T,

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
@@ -8,31 +8,14 @@ impl<'a> Deserializer<'a> {
     }
 
     pub fn take_u64(&mut self) -> u64 {
-        #[cfg(target_endian = "little")]
-        {
-            let ptr = std::ptr::addr_of!(self.bytes[0]) as *const u64;
-            let val = unsafe { std::ptr::read_unaligned(ptr) };
-            self.bytes = &self.bytes[8..];
-            val
-        }
-        #[cfg(not(target_endian = "little"))]
         self.take_one(u64::from_le_bytes)
     }
 
     pub fn take_u128(&mut self) -> u128 {
-        #[cfg(target_endian = "little")]
-        {
-            let ptr = std::ptr::addr_of!(self.bytes[0]) as *const u128;
-            let val = unsafe { std::ptr::read_unaligned(ptr) };
-            self.bytes = &self.bytes[16..];
-            val
-        }
-        #[cfg(not(target_endian = "little"))]
         self.take_one(u128::from_le_bytes)
     }
 
     #[inline]
-    #[cfg(not(target_endian = "little"))]
     fn take_one<FBuild, T, const SIZE: usize>(&mut self, builder: FBuild) -> T
     where
         FBuild: Fn([u8; SIZE]) -> T,

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -14,6 +14,7 @@ pub struct Sessions {
     // Session IDs are stored in little endian byte form in a compact array to accelerate serialization.
     // When a session ID is queried (via session space ref) the bytes are converted to a u128/Session ID.
     // This tradeoff favors serialization at a small penalty to the (already slow) path of decompress/recompress.
+    // NOTE: this is indexed by session_space_ref.index * sizeof(u128)
     session_ids: Vec<u8>,
 }
 

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -2,7 +2,7 @@
 The local/UUID space within an individual Session.
 Effectively represents the cluster chain for a given session.
 */
-use id_types::session_id::from_stable_id;
+use id_types::session_id::{session_id_from_id_u128, stable_id_from_stable_id};
 use id_types::{FinalId, LocalId, SessionId, StableId};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -49,7 +49,7 @@ impl Sessions {
             .try_into()
             .unwrap();
         let id_128 = u128::from_le_bytes(bytes);
-        SessionId::from_id_u128(id_128)
+        session_id_from_id_u128(id_128)
     }
 
     pub fn get(&self, session_id: SessionId) -> Option<&SessionSpaceRef> {
@@ -95,7 +95,7 @@ impl Sessions {
             .session_map
             .range((
                 Bound::Excluded(SessionId::nil()),
-                Bound::Included(from_stable_id(query)),
+                Bound::Included(stable_id_from_stable_id(query)),
             ))
             .rev();
         match range.next() {
@@ -138,7 +138,7 @@ impl Sessions {
             .session_map
             .range((
                 Bound::Excluded(SessionId::nil()),
-                Bound::Included(from_stable_id(range_max)),
+                Bound::Included(stable_id_from_stable_id(range_max)),
             ))
             .rev();
         match range.next() {

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -1,4 +1,4 @@
-use id_types::session_id::{session_id_from_id_u128, stable_id_from_stable_id};
+use id_types::session_id::{session_id_from_id_u128, session_id_from_stable_id};
 use id_types::{FinalId, LocalId, SessionId, StableId};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -95,7 +95,7 @@ impl Sessions {
             .session_map
             .range((
                 Bound::Excluded(SessionId::nil()),
-                Bound::Included(stable_id_from_stable_id(query)),
+                Bound::Included(session_id_from_stable_id(query)),
             ))
             .rev();
         match range.next() {
@@ -138,7 +138,7 @@ impl Sessions {
             .session_map
             .range((
                 Bound::Excluded(SessionId::nil()),
-                Bound::Included(stable_id_from_stable_id(range_max)),
+                Bound::Included(session_id_from_stable_id(range_max)),
             ))
             .rev();
         match range.next() {

--- a/rust-wasm-id-allocator/id-types/src/session_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_id.rs
@@ -57,7 +57,7 @@ pub fn session_id_from_id_u128(id_u128: u128) -> SessionId {
 }
 
 /// Internal type conversion
-pub fn stable_id_from_stable_id(stable_id: StableId) -> SessionId {
+pub fn session_id_from_stable_id(stable_id: StableId) -> SessionId {
     SessionId { id: stable_id }
 }
 

--- a/rust-wasm-id-allocator/id-types/src/session_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_id.rs
@@ -41,9 +41,16 @@ impl SessionId {
         }
     }
 
-    /// Creates a new SessionId from the supplied UUID in bit form. Intended for internal use only.
+    /// Creates a new SessionId from the supplied UUID in number form. Intended for internal use only.
     pub fn from_uuid_u128(uuid_u128: u128) -> SessionId {
         uuid::Builder::from_u128(uuid_u128).into_uuid().into()
+    }
+
+    /// Creates a new SessionId from the supplied u128 in internal ID form. Intended for internal use only.
+    pub fn from_id_u128(id_u128: u128) -> SessionId {
+        SessionId {
+            id: StableId { id: id_u128 },
+        }
     }
 }
 
@@ -56,6 +63,12 @@ impl From<Uuid> for SessionId {
 impl From<SessionId> for String {
     fn from(value: SessionId) -> Self {
         value.id.into()
+    }
+}
+
+impl From<SessionId> for [u8; 16] {
+    fn from(value: SessionId) -> Self {
+        value.id.id.to_le_bytes()
     }
 }
 

--- a/rust-wasm-id-allocator/id-types/src/session_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_id.rs
@@ -40,18 +40,25 @@ impl SessionId {
             }
         }
     }
+}
 
-    /// Creates a new SessionId from the supplied UUID in number form. Intended for internal use only.
-    pub fn from_uuid_u128(uuid_u128: u128) -> SessionId {
-        uuid::Builder::from_u128(uuid_u128).into_uuid().into()
-    }
+/// Creates a new SessionId from the supplied UUID in number form.
+/// Free function to keep it internal.
+pub fn session_id_from_uuid_u128(uuid_u128: u128) -> SessionId {
+    uuid::Builder::from_u128(uuid_u128).into_uuid().into()
+}
 
-    /// Creates a new SessionId from the supplied u128 in internal ID form. Intended for internal use only.
-    pub fn from_id_u128(id_u128: u128) -> SessionId {
-        SessionId {
-            id: StableId { id: id_u128 },
-        }
+/// Creates a new SessionId from the supplied u128 in internal ID form.
+/// Free function to keep it internal.
+pub fn session_id_from_id_u128(id_u128: u128) -> SessionId {
+    SessionId {
+        id: StableId { id: id_u128 },
     }
+}
+
+/// Internal type conversion
+pub fn stable_id_from_stable_id(stable_id: StableId) -> SessionId {
+    SessionId { id: stable_id }
 }
 
 impl From<Uuid> for SessionId {
@@ -82,11 +89,6 @@ impl From<SessionId> for StableId {
     fn from(value: SessionId) -> Self {
         value.id
     }
-}
-
-/// Internal type conversion
-pub fn from_stable_id(stable_id: StableId) -> SessionId {
-    SessionId { id: stable_id }
 }
 
 impl std::ops::Add<LocalId> for SessionId {

--- a/rust-wasm-id-allocator/id-types/src/stable_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/stable_id.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 /// A compressed version 4, variant 1 UUID (https://datatracker.ietf.org/doc/html/rfc4122).
 /// Can be converted to a UUID, u128, or String as needed.
 pub struct StableId {
-    id: u128,
+    pub(crate) id: u128,
 }
 
 impl StableId {


### PR DESCRIPTION
Models session ids as a byte slice (with conversion in the getters) to allow streamlined serialization.
Also cleans up the persistence utils.
All said, a 70% reduction in time spent in serialization (now at 80x faster than TS).