### PR TITLE
Revert vec preallocation

### DIFF
--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -207,7 +207,7 @@ pub struct SessionSpace {
 impl SessionSpace {
     pub fn new() -> SessionSpace {
         SessionSpace {
-            cluster_chain: Vec::with_capacity(1),
+            cluster_chain: Vec::new(),
         }
     }
 


### PR DESCRIPTION
It has uncertain benefit and regresses deserialize perf by 30%.