### PR TITLE
Serialize numbers as 32 bit when clusters are "small"

### DIFF
--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor.rs
@@ -6,6 +6,7 @@ use self::tables::final_space::FinalSpace;
 use self::tables::session_space::{ClusterRef, SessionSpace, SessionSpaceRef, Sessions};
 use self::tables::session_space_normalizer::SessionSpaceNormalizer;
 use id_types::final_id::final_id_from_id;
+use id_types::local_id::local_id_from_id;
 use id_types::*;
 
 /// The reserved value for an unknown token index.
@@ -78,7 +79,7 @@ impl IdCompressor {
             session_id,
             local_session_ref: sessions.get_or_create(session_id),
             generated_id_count: 0,
-            next_range_base_generation_count: LocalId::from_id(-1).to_generation_count(),
+            next_range_base_generation_count: local_id_from_id(-1).to_generation_count(),
             sessions,
             final_space: FinalSpace::new(),
             final_id_limit: final_id_from_id(0),
@@ -168,7 +169,7 @@ impl IdCompressor {
 
     fn generate_next_local_id(&mut self) -> LocalId {
         self.telemetry_stats.local_id_count += 1;
-        let new_local = LocalId::from_id(-(self.generated_id_count as i64));
+        let new_local = local_id_from_id(-(self.generated_id_count as i64));
         self.session_space_normalizer.add_local_range(new_local, 1);
         new_local
     }

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor.rs
@@ -5,6 +5,7 @@ use self::persistence::DeserializationError;
 use self::tables::final_space::FinalSpace;
 use self::tables::session_space::{ClusterRef, SessionSpace, SessionSpaceRef, Sessions};
 use self::tables::session_space_normalizer::SessionSpaceNormalizer;
+use id_types::final_id::final_id_from_id;
 use id_types::*;
 
 /// The reserved value for an unknown token index.
@@ -80,7 +81,7 @@ impl IdCompressor {
             next_range_base_generation_count: LocalId::from_id(-1).to_generation_count(),
             sessions,
             final_space: FinalSpace::new(),
-            final_id_limit: FinalId::from_id(0),
+            final_id_limit: final_id_from_id(0),
             session_space_normalizer: SessionSpaceNormalizer::new(),
             cluster_capacity: persistence::DEFAULT_CLUSTER_CAPACITY,
             telemetry_stats: TelemetryStats::EMPTY,
@@ -301,7 +302,7 @@ impl IdCompressor {
     ) -> ClusterRef {
         let next_base_final = match self.final_space.get_tail_cluster(&self.sessions) {
             Some(cluster) => cluster.base_final_id + cluster.capacity,
-            None => FinalId::from_id(0),
+            None => final_id_from_id(0),
         };
         let session_space = self.sessions.deref_session_space_mut(session_space_ref);
         let new_cluster_ref = session_space.add_empty_cluster(

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
@@ -11,7 +11,7 @@ where
     FMakeSession: FnOnce() -> SessionId,
 {
     let mut deserializer = Deserializer::new(bytes);
-    let version = deserializer.take_u64();
+    let version = deserializer.take_u32();
     match version {
         1 => v1::deserialize(&mut deserializer, make_session_id),
         _ => Err(DeserializationError::UnknownVersion),
@@ -41,9 +41,11 @@ pub mod v1 {
     use crate::{
         compressor::IdCompressor,
         compressor::{
-            persistence_utils::{write_u128_to_vec, write_u64_to_vec, Deserializer},
+            persistence_utils::{
+                write_u128_to_vec, write_u32_to_vec, write_u64_to_vec, Deserializer,
+            },
             tables::{
-                session_space::IdCluster,
+                session_space::{ClusterRef, IdCluster},
                 session_space_normalizer::persistence::v1::{
                     deserialize_normalizer, serialize_normalizer,
                 },
@@ -51,12 +53,16 @@ pub mod v1 {
         },
     };
     use id_types::{
+        final_id::get_id_from_final_id,
         session_id::{session_id_from_id_u128, session_id_from_uuid_u128},
         FinalId, LocalId, SessionId, StableId,
     };
 
     // Layout
-    // has_local_state: bool as u64
+    // version: u32
+    // has_local_state: bool as u32
+    // clusters_are_32_bit: bool as u32
+    // if has_local_state
     //      session_uuid_u128: u128,
     //      generated_id_count: u64,
     //      next_range_base_generation_count: u64,
@@ -67,29 +73,59 @@ pub mod v1 {
 
     pub fn serialize(compressor: &IdCompressor) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::new();
-        serialize_header(false, &mut bytes);
-        serialize_finalized(compressor, &mut bytes);
+        let is_32_bit = serialize_header(compressor, false, &mut bytes);
+        serialize_finalized(compressor, is_32_bit, &mut bytes);
         bytes
     }
 
     pub fn serialize_with_local(compressor: &IdCompressor) -> Vec<u8> {
         let mut bytes: Vec<u8> = Vec::new();
-        serialize_header(true, &mut bytes);
+        let is_32_bit = serialize_header(compressor, true, &mut bytes);
         write_u128_to_vec(&mut bytes, StableId::from(compressor.session_id).into());
         write_u64_to_vec(&mut bytes, compressor.generated_id_count);
         write_u64_to_vec(&mut bytes, compressor.next_range_base_generation_count);
         serialize_normalizer(&compressor.session_space_normalizer, &mut bytes);
-        serialize_finalized(compressor, &mut bytes);
+        serialize_finalized(compressor, is_32_bit, &mut bytes);
         bytes
     }
 
-    fn serialize_header(is_local: bool, bytes: &mut Vec<u8>) {
+    fn serialize_header(compressor: &IdCompressor, is_local: bool, bytes: &mut Vec<u8>) -> bool {
         // Version
-        write_u64_to_vec(bytes, 1);
-        write_u64_to_vec(bytes, is_local as u64);
+        write_u32_to_vec(bytes, 1);
+        write_u32_to_vec(bytes, is_local as u32);
+        let is_32_bit = match compressor
+            .final_space
+            .get_tail_cluster(&compressor.sessions)
+        {
+            Some(cluster) => get_id_from_final_id(cluster.max_allocated_final()),
+            None => 0,
+        } < u32::MAX as u64;
+        write_u32_to_vec(bytes, is_32_bit as u32);
+        is_32_bit
     }
 
-    fn serialize_finalized(compressor: &IdCompressor, bytes: &mut Vec<u8>) {
+    fn serialize_finalized(compressor: &IdCompressor, is_32_bit: bool, bytes: &mut Vec<u8>) {
+        let write_cluster: fn(cluster: &IdCluster, cluster_ref: ClusterRef, bytes: &mut Vec<u8>) =
+            if is_32_bit {
+                |cluster, cluster_ref, bytes| {
+                    write_u32_to_vec(
+                        bytes,
+                        cluster_ref.get_session_space_ref().get_index() as u32,
+                    );
+                    write_u32_to_vec(bytes, cluster.capacity as u32);
+                    write_u32_to_vec(bytes, cluster.count as u32);
+                }
+            } else {
+                |cluster, cluster_ref, bytes| {
+                    write_u64_to_vec(
+                        bytes,
+                        cluster_ref.get_session_space_ref().get_index() as u64,
+                    );
+                    write_u64_to_vec(bytes, cluster.capacity);
+                    write_u64_to_vec(bytes, cluster.count);
+                }
+            };
+
         write_u64_to_vec(bytes, compressor.cluster_capacity);
         write_u64_to_vec(bytes, compressor.sessions.get_session_count() as u64);
 
@@ -100,12 +136,7 @@ pub mod v1 {
             .final_space
             .get_clusters(&compressor.sessions)
             .for_each(|(id_cluster, cluster_ref)| {
-                write_u64_to_vec(
-                    bytes,
-                    cluster_ref.get_session_space_ref().get_index() as u64,
-                );
-                write_u64_to_vec(bytes, id_cluster.capacity);
-                write_u64_to_vec(bytes, id_cluster.count);
+                write_cluster(id_cluster, cluster_ref, bytes);
             });
     }
 
@@ -116,7 +147,8 @@ pub mod v1 {
     where
         FMakeSession: FnOnce() -> SessionId,
     {
-        let with_local_state = deserializer.take_u64() != 0;
+        let with_local_state = deserializer.take_u32() != 0;
+        let is_32_bit = deserializer.take_u32() != 0;
         let mut compressor = match with_local_state {
             false => IdCompressor::new_with_session_id(make_session_id()),
             true => {
@@ -142,11 +174,21 @@ pub mod v1 {
             session_ref_remap.push(compressor.sessions.get_or_create(session_id));
         }
 
+        let read_cluster: fn(deserializer: &mut Deserializer) -> (u64, u64, u64) = if is_32_bit {
+            |deser| {
+                (
+                    deser.take_u32() as u64,
+                    deser.take_u32() as u64,
+                    deser.take_u32() as u64,
+                )
+            }
+        } else {
+            |deser| (deser.take_u64(), deser.take_u64(), deser.take_u64())
+        };
+
         let cluster_count = deserializer.take_u64();
         for _ in 0..cluster_count {
-            let session_index = deserializer.take_u64();
-            let capacity = deserializer.take_u64();
-            let count = deserializer.take_u64();
+            let (session_index, capacity, count) = read_cluster(deserializer);
 
             let base_final_id = match compressor
                 .final_space

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence.rs
@@ -53,9 +53,9 @@ pub mod v1 {
         },
     };
     use id_types::{
-        final_id::get_id_from_final_id,
+        final_id::{final_id_from_id, get_id_from_final_id},
         session_id::{session_id_from_id_u128, session_id_from_uuid_u128},
-        FinalId, LocalId, SessionId, StableId,
+        LocalId, SessionId, StableId,
     };
 
     // Layout
@@ -195,7 +195,7 @@ pub mod v1 {
                 .get_tail_cluster(&compressor.sessions)
             {
                 Some(cluster) => cluster.base_final_id + cluster.capacity,
-                None => FinalId::from_id(0),
+                None => final_id_from_id(0),
             };
             let session_space_ref = session_ref_remap[session_index as usize];
             let session_space = compressor.sessions.deref_session_space(session_space_ref);
@@ -222,7 +222,7 @@ pub mod v1 {
             .get_tail_cluster(&compressor.sessions)
         {
             Some(cluster) => cluster.base_final_id + cluster.count,
-            None => FinalId::from_id(0),
+            None => final_id_from_id(0),
         };
         Ok(compressor)
     }

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/persistence_utils.rs
@@ -7,6 +7,10 @@ impl<'a> Deserializer<'a> {
         Self { bytes }
     }
 
+    pub fn take_u32(&mut self) -> u32 {
+        self.take_one(u32::from_le_bytes)
+    }
+
     pub fn take_u64(&mut self) -> u64 {
         self.take_one(u64::from_le_bytes)
     }
@@ -32,6 +36,11 @@ where
 {
     let val_arr = builder(val);
     bytes.extend_from_slice(&val_arr);
+}
+
+#[inline]
+pub fn write_u32_to_vec(buffer: &mut Vec<u8>, num: u32) {
+    write_to_vec(buffer, num, |val: u32| val.to_le_bytes());
 }
 
 #[inline]

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -1,3 +1,4 @@
+use id_types::local_id::local_id_from_id;
 use id_types::session_id::{session_id_from_id_u128, session_id_from_stable_id};
 use id_types::{FinalId, LocalId, SessionId, StableId};
 use std::cmp::Ordering;
@@ -115,7 +116,7 @@ impl Sessions {
                         let cluster_min_stable = result_session_id + cluster_match.base_local_id;
                         let cluster_max_stable = cluster_min_stable + cluster_match.capacity;
                         if query >= cluster_min_stable && query <= cluster_max_stable {
-                            let originator_local = LocalId::from_id(
+                            let originator_local = local_id_from_id(
                                 -((query - StableId::from(result_session_id)) as i64) - 1,
                             );
                             Some((cluster_match, session_space_ref, originator_local))

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space_normalizer.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space_normalizer.rs
@@ -41,51 +41,53 @@ impl SessionSpaceNormalizer {
 
 #[cfg(test)]
 mod tests {
+    use id_types::local_id::local_id_from_id;
+
     use super::*;
 
     #[test]
     fn test_empty() {
         let session_space_normalizer = SessionSpaceNormalizer::new();
-        assert!(!session_space_normalizer.contains(LocalId::from_id(-1)));
+        assert!(!session_space_normalizer.contains(local_id_from_id(-1)));
     }
 
     #[test]
     fn test_single() {
         let mut session_space_normalizer = SessionSpaceNormalizer::new();
-        session_space_normalizer.add_local_range(LocalId::from_id(-1), 5);
-        assert!(session_space_normalizer.contains(LocalId::from_id(-1)));
-        assert!(session_space_normalizer.contains(LocalId::from_id(-2)));
+        session_space_normalizer.add_local_range(local_id_from_id(-1), 5);
+        assert!(session_space_normalizer.contains(local_id_from_id(-1)));
+        assert!(session_space_normalizer.contains(local_id_from_id(-2)));
     }
 
     #[test]
     fn test_discontiguous() {
         let mut session_space_normalizer = SessionSpaceNormalizer::new();
-        session_space_normalizer.add_local_range(LocalId::from_id(-1), 2);
-        session_space_normalizer.add_local_range(LocalId::from_id(-6), 4);
-        session_space_normalizer.add_local_range(LocalId::from_id(-15), 1);
-        assert!(!session_space_normalizer.contains(LocalId::from_id(-11)));
-        assert!(!session_space_normalizer.contains(LocalId::from_id(-3)));
-        assert!(session_space_normalizer.contains(LocalId::from_id(-7)));
+        session_space_normalizer.add_local_range(local_id_from_id(-1), 2);
+        session_space_normalizer.add_local_range(local_id_from_id(-6), 4);
+        session_space_normalizer.add_local_range(local_id_from_id(-15), 1);
+        assert!(!session_space_normalizer.contains(local_id_from_id(-11)));
+        assert!(!session_space_normalizer.contains(local_id_from_id(-3)));
+        assert!(session_space_normalizer.contains(local_id_from_id(-7)));
     }
 
     #[test]
     fn test_contiguous() {
         let mut session_space_normalizer = SessionSpaceNormalizer::new();
-        session_space_normalizer.add_local_range(LocalId::from_id(-1), 2);
-        session_space_normalizer.add_local_range(LocalId::from_id(-3), 4);
-        session_space_normalizer.add_local_range(LocalId::from_id(-15), 1);
-        assert!(session_space_normalizer.contains(LocalId::from_id(-1)));
-        assert!(session_space_normalizer.contains(LocalId::from_id(-4)));
-        assert!(session_space_normalizer.contains(LocalId::from_id(-6)));
-        assert!(!session_space_normalizer.contains(LocalId::from_id(-7)));
-        assert!(session_space_normalizer.contains(LocalId::from_id(-15)));
+        session_space_normalizer.add_local_range(local_id_from_id(-1), 2);
+        session_space_normalizer.add_local_range(local_id_from_id(-3), 4);
+        session_space_normalizer.add_local_range(local_id_from_id(-15), 1);
+        assert!(session_space_normalizer.contains(local_id_from_id(-1)));
+        assert!(session_space_normalizer.contains(local_id_from_id(-4)));
+        assert!(session_space_normalizer.contains(local_id_from_id(-6)));
+        assert!(!session_space_normalizer.contains(local_id_from_id(-7)));
+        assert!(session_space_normalizer.contains(local_id_from_id(-15)));
     }
 
     #[test]
     fn test_contains() {
         let mut session_space_normalizer = SessionSpaceNormalizer::new();
-        session_space_normalizer.add_local_range(LocalId::from_id(-1), 2);
-        session_space_normalizer.add_local_range(LocalId::from_id(-6), 2);
-        assert!(!session_space_normalizer.contains(LocalId::from_id(-3)));
+        session_space_normalizer.add_local_range(local_id_from_id(-1), 2);
+        session_space_normalizer.add_local_range(local_id_from_id(-6), 2);
+        assert!(!session_space_normalizer.contains(local_id_from_id(-3)));
     }
 }

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space_normalizer/persistence.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space_normalizer/persistence.rs
@@ -42,14 +42,14 @@ mod tests {
     use crate::compressor::{
         persistence_utils::Deserializer, tables::session_space_normalizer::SessionSpaceNormalizer,
     };
-    use id_types::LocalId;
+    use id_types::local_id::local_id_from_id;
 
     #[test]
     fn test_serde_normalizer() {
         let mut session_space_normalizer = SessionSpaceNormalizer::new();
-        session_space_normalizer.add_local_range(LocalId::from_id(-1), 2);
-        session_space_normalizer.add_local_range(LocalId::from_id(-3), 4);
-        session_space_normalizer.add_local_range(LocalId::from_id(-15), 1);
+        session_space_normalizer.add_local_range(local_id_from_id(-1), 2);
+        session_space_normalizer.add_local_range(local_id_from_id(-3), 4);
+        session_space_normalizer.add_local_range(local_id_from_id(-15), 1);
 
         let mut bytes: Vec<u8> = Vec::new();
         serialize_normalizer(&session_space_normalizer, &mut bytes);

--- a/rust-wasm-id-allocator/id-types/src/final_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/final_id.rs
@@ -10,8 +10,8 @@ pub const fn final_id_from_id(id: u64) -> FinalId {
     FinalId { id }
 }
 
-/// Creates a final ID from a u64. Intended for internal use only.
-pub fn get_id_from_final_id(final_id: FinalId) -> u64 {
+/// Gets a u64 from a final ID. Intended for internal use only.
+pub const fn get_id_from_final_id(final_id: FinalId) -> u64 {
     final_id.id
 }
 

--- a/rust-wasm-id-allocator/id-types/src/final_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/final_id.rs
@@ -16,6 +16,16 @@ impl FinalId {
     }
 }
 
+/// Creates a final ID from a u64. Intended for internal use only.
+pub const fn final_id_from_id(id: u64) -> FinalId {
+    FinalId { id }
+}
+
+/// Creates a final ID from a u64. Intended for internal use only.
+pub fn get_id_from_final_id(final_id: FinalId) -> u64 {
+    final_id.id
+}
+
 impl std::ops::Add<u64> for FinalId {
     type Output = FinalId;
     fn add(self, rhs: u64) -> Self::Output {

--- a/rust-wasm-id-allocator/id-types/src/final_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/final_id.rs
@@ -2,18 +2,7 @@
 /// A compressed ID that is stable and unique within the scope of network of compressors (i.e. a document).
 /// It can only be used/decompressed in the context of the originating document.
 pub struct FinalId {
-    id: u64,
-}
-
-impl FinalId {
-    pub(super) fn id(&self) -> u64 {
-        self.id
-    }
-
-    /// Creates a final ID from a u64. Intended for internal use only.
-    pub fn from_id(id: u64) -> Self {
-        FinalId { id }
-    }
+    pub(crate) id: u64,
 }
 
 /// Creates a final ID from a u64. Intended for internal use only.

--- a/rust-wasm-id-allocator/id-types/src/local_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/local_id.rs
@@ -9,21 +9,6 @@ pub struct LocalId {
 }
 
 impl LocalId {
-    /// Creates a local ID from a i64. Intended for internal use only.
-    pub fn from_id(id: i64) -> LocalId {
-        debug_assert!(
-            id < 0,
-            "Local ID must be negative. Passed value was {}.",
-            id,
-        );
-        LocalId { id }
-    }
-
-    /// Returns the inner ID as an i64. Intended for internal use only.
-    pub fn id(&self) -> i64 {
-        self.id
-    }
-
     /// Returns the inner ID as a generation count. Intended for internal use only.
     pub fn to_generation_count(&self) -> u64 {
         (-self.id) as u64
@@ -31,8 +16,23 @@ impl LocalId {
 
     /// Creates a local ID from a generation count. Intended for internal use only.
     pub fn from_generation_count(generation_count: u64) -> Self {
-        LocalId::from_id(-(generation_count as i64))
+        local_id_from_id(-(generation_count as i64))
     }
+}
+
+/// Creates a local ID from an i64. Intended for internal use only.
+pub fn local_id_from_id(id: i64) -> LocalId {
+    debug_assert!(
+        id < 0,
+        "Local ID must be negative. Passed value was {}.",
+        id,
+    );
+    LocalId { id }
+}
+
+/// Gets an i64 from a local ID. Intended for internal use only.
+pub const fn get_id_from_local_id(local_id: LocalId) -> i64 {
+    local_id.id
 }
 
 impl PartialEq<i64> for LocalId {
@@ -44,6 +44,6 @@ impl PartialEq<i64> for LocalId {
 impl Sub<u64> for LocalId {
     type Output = LocalId;
     fn sub(self, rhs: u64) -> Self::Output {
-        LocalId::from_id(self.id - rhs as i64)
+        local_id_from_id(self.id - rhs as i64)
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/op_space_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/op_space_id.rs
@@ -1,4 +1,7 @@
-use crate::final_id::final_id_from_id;
+use crate::{
+    final_id::final_id_from_id,
+    local_id::{get_id_from_local_id, local_id_from_id},
+};
 
 use super::*;
 
@@ -24,7 +27,7 @@ impl OpSpaceId {
     /// Maps the ID to local or final space. Intended for internal use only.
     pub fn to_space(&self) -> CompressedId {
         if self.is_local() {
-            CompressedId::Local(LocalId::from_id(self.id))
+            CompressedId::Local(local_id_from_id(self.id))
         } else {
             CompressedId::Final(final_id_from_id(self.id as u64))
         }
@@ -51,6 +54,8 @@ impl From<FinalId> for OpSpaceId {
 
 impl From<LocalId> for OpSpaceId {
     fn from(local_id: LocalId) -> Self {
-        OpSpaceId { id: local_id.id() }
+        OpSpaceId {
+            id: get_id_from_local_id(local_id),
+        }
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/op_space_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/op_space_id.rs
@@ -1,3 +1,5 @@
+use crate::final_id::final_id_from_id;
+
 use super::*;
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
@@ -24,7 +26,7 @@ impl OpSpaceId {
         if self.is_local() {
             CompressedId::Local(LocalId::from_id(self.id))
         } else {
-            CompressedId::Final(FinalId::from_id(self.id as u64))
+            CompressedId::Final(final_id_from_id(self.id as u64))
         }
     }
 
@@ -42,7 +44,7 @@ impl OpSpaceId {
 impl From<FinalId> for OpSpaceId {
     fn from(final_id: FinalId) -> Self {
         OpSpaceId {
-            id: final_id.id() as i64,
+            id: final_id.id as i64,
         }
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/session_space_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_space_id.rs
@@ -1,4 +1,7 @@
-use crate::final_id::final_id_from_id;
+use crate::{
+    final_id::final_id_from_id,
+    local_id::{get_id_from_local_id, local_id_from_id},
+};
 
 use super::*;
 
@@ -24,7 +27,7 @@ impl SessionSpaceId {
     /// Maps the ID to local or final space. Intended for internal use only.
     pub fn to_space(&self) -> CompressedId {
         if self.is_local() {
-            CompressedId::Local(LocalId::from_id(self.id))
+            CompressedId::Local(local_id_from_id(self.id))
         } else {
             CompressedId::Final(final_id_from_id(self.id as u64))
         }
@@ -43,7 +46,9 @@ impl SessionSpaceId {
 
 impl From<LocalId> for SessionSpaceId {
     fn from(local_id: LocalId) -> Self {
-        SessionSpaceId { id: local_id.id() }
+        SessionSpaceId {
+            id: get_id_from_local_id(local_id),
+        }
     }
 }
 

--- a/rust-wasm-id-allocator/id-types/src/session_space_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_space_id.rs
@@ -1,3 +1,5 @@
+use crate::final_id::final_id_from_id;
+
 use super::*;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -24,7 +26,7 @@ impl SessionSpaceId {
         if self.is_local() {
             CompressedId::Local(LocalId::from_id(self.id))
         } else {
-            CompressedId::Final(FinalId::from_id(self.id as u64))
+            CompressedId::Final(final_id_from_id(self.id as u64))
         }
     }
 
@@ -48,7 +50,7 @@ impl From<LocalId> for SessionSpaceId {
 impl From<FinalId> for SessionSpaceId {
     fn from(final_id: FinalId) -> Self {
         SessionSpaceId {
-            id: final_id.id() as i64,
+            id: final_id.id as i64,
         }
     }
 }

--- a/rust-wasm-id-allocator/wasm-id-allocator/src/lib.rs
+++ b/rust-wasm-id-allocator/wasm-id-allocator/src/lib.rs
@@ -297,7 +297,7 @@ impl TestOnly {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use id_types::LocalId;
+    use id_types::{local_id::get_id_from_local_id, LocalId};
 
     const _STABLE_ID_1: &str = "748540ca-b7c5-4c99-83ff-c1b8e02c09d6";
     const _STABLE_ID_2: &str = "0002c79e-b536-4776-b000-000266c252d5";
@@ -363,7 +363,8 @@ mod tests {
             count,
         } = interop_id_range.unwrap();
         assert_eq!(
-            LocalId::from_generation_count(first_local_gen_count as u64).id() as f64,
+            get_id_from_local_id(LocalId::from_generation_count(first_local_gen_count as u64))
+                as f64,
             generated_ids[0]
         );
         assert_eq!(count, generated_ids.len() as f64);

--- a/typescript-id-allocator/test/id-compressor/idCompressor.spec.ts
+++ b/typescript-id-allocator/test/id-compressor/idCompressor.spec.ts
@@ -199,7 +199,7 @@ describe("IdCompressor", () => {
 			mockLogger.assertMatchAny([
 				{
 					eventName: "RuntimeIdCompressor:SerializedIdCompressorSize",
-					size: 80,
+					size: 64,
 				},
 			]);
 		});


### PR DESCRIPTION
~40% reduction in size, 6% speedup in serialization, 2% speedup in deserialization.

Also, make FinalId/LocalId's internal creation/access methods free functions instead to make them internal.