### PR TITLE
as casts removed from core and id-types

### DIFF
--- a/rust-wasm-id-allocator/id-types/src/final_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/final_id.rs
@@ -26,6 +26,6 @@ impl std::ops::Sub<FinalId> for FinalId {
     type Output = i64;
     fn sub(self, rhs: FinalId) -> Self::Output {
         debug_assert!(self.id >= rhs.id, "Final ID subtraction overflow");
-        self.id as i64 - rhs.id as i64
+        i64::try_from(self.id).unwrap() - i64::try_from(rhs.id).unwrap()
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/local_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/local_id.rs
@@ -11,12 +11,12 @@ pub struct LocalId {
 impl LocalId {
     /// Returns the inner ID as a generation count. Intended for internal use only.
     pub fn to_generation_count(&self) -> u64 {
-        (-self.id) as u64
+        (-self.id).try_into().unwrap()
     }
 
     /// Creates a local ID from a generation count. Intended for internal use only.
     pub fn from_generation_count(generation_count: u64) -> Self {
-        local_id_from_id(-(generation_count as i64))
+        local_id_from_id(-(i64::try_from(generation_count).unwrap()))
     }
 }
 
@@ -44,6 +44,6 @@ impl PartialEq<i64> for LocalId {
 impl Sub<u64> for LocalId {
     type Output = LocalId;
     fn sub(self, rhs: u64) -> Self::Output {
-        local_id_from_id(self.id - rhs as i64)
+        local_id_from_id(self.id - i64::try_from(rhs).unwrap())
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/op_space_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/op_space_id.rs
@@ -29,7 +29,7 @@ impl OpSpaceId {
         if self.is_local() {
             CompressedId::Local(local_id_from_id(self.id))
         } else {
-            CompressedId::Final(final_id_from_id(self.id as u64))
+            CompressedId::Final(final_id_from_id(self.id.try_into().unwrap()))
         }
     }
 
@@ -47,7 +47,7 @@ impl OpSpaceId {
 impl From<FinalId> for OpSpaceId {
     fn from(final_id: FinalId) -> Self {
         OpSpaceId {
-            id: final_id.id as i64,
+            id: final_id.id.try_into().unwrap(),
         }
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/session_space_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/session_space_id.rs
@@ -29,7 +29,7 @@ impl SessionSpaceId {
         if self.is_local() {
             CompressedId::Local(local_id_from_id(self.id))
         } else {
-            CompressedId::Final(final_id_from_id(self.id as u64))
+            CompressedId::Final(final_id_from_id(self.id.try_into().unwrap()))
         }
     }
 
@@ -55,7 +55,7 @@ impl From<LocalId> for SessionSpaceId {
 impl From<FinalId> for SessionSpaceId {
     fn from(final_id: FinalId) -> Self {
         SessionSpaceId {
-            id: final_id.id as i64,
+            id: final_id.id.try_into().unwrap(),
         }
     }
 }

--- a/rust-wasm-id-allocator/id-types/src/stable_id.rs
+++ b/rust-wasm-id-allocator/id-types/src/stable_id.rs
@@ -84,7 +84,7 @@ impl std::ops::Add<LocalId> for StableId {
     type Output = Self;
     fn add(self, rhs: LocalId) -> Self::Output {
         StableId {
-            id: self.id + (rhs.to_generation_count() - 1) as u128,
+            id: self.id + u128::from(rhs.to_generation_count() - 1),
         }
     }
 }
@@ -93,7 +93,7 @@ impl std::ops::Add<u64> for StableId {
     type Output = Self;
     fn add(self, rhs: u64) -> Self::Output {
         StableId {
-            id: self.id + rhs as u128,
+            id: self.id + u128::from(rhs),
         }
     }
 }
@@ -101,9 +101,9 @@ impl std::ops::Add<u64> for StableId {
 impl std::ops::Sub<u64> for StableId {
     type Output = Self;
     fn sub(self, rhs: u64) -> Self::Output {
-        debug_assert!(self.id >= rhs as u128);
+        debug_assert!(self.id >= u128::from(rhs));
         StableId {
-            id: self.id - rhs as u128,
+            id: self.id - u128::from(rhs),
         }
     }
 }


### PR DESCRIPTION
Addressing Issue #51.

Initial removal of as-cast pattern in core allocator and id-types.