### PR TITLE
Use AVL tree instead of btree

### DIFF
--- a/rust-wasm-id-allocator/Cargo.lock
+++ b/rust-wasm-id-allocator/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "avl"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1249cb3effef43713024f23137529eb78c42bf288e7c60475b479f2e63f7379e"
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +24,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "distributed-id-allocator"
 version = "0.1.0"
 dependencies = [
+ "avl",
  "id-types",
  "uuid",
 ]

--- a/rust-wasm-id-allocator/distributed-id-allocator/Cargo.toml
+++ b/rust-wasm-id-allocator/distributed-id-allocator/Cargo.toml
@@ -15,3 +15,4 @@ features = [
 
 [dependencies]
 id-types = { path = "../../rust-wasm-id-allocator/id-types", version = "0.1", default-features = false }
+avl = "0.7.1"

--- a/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
+++ b/rust-wasm-id-allocator/distributed-id-allocator/src/compressor/tables/session_space.rs
@@ -1,15 +1,15 @@
+use avl::AvlTreeMap;
 use id_types::local_id::local_id_from_id;
 use id_types::session_id::{session_id_from_id_u128, session_id_from_stable_id};
 use id_types::{FinalId, LocalId, SessionId, StableId};
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
 use std::mem::size_of;
 use std::ops::Bound;
 
 /// The local/UUID space within an individual Session.
 /// Effectively represents the cluster chain for a given session.
 pub struct Sessions {
-    session_map: BTreeMap<SessionId, SessionSpaceRef>,
+    session_map: AvlTreeMap<SessionId, SessionSpaceRef>,
     session_list: Vec<SessionSpace>,
     // Session IDs are stored in little endian byte form in a compact array to accelerate serialization.
     // When a session ID is queried (via session space ref) the bytes are converted to a u128/Session ID.
@@ -21,7 +21,7 @@ pub struct Sessions {
 impl Sessions {
     pub fn new() -> Sessions {
         Sessions {
-            session_map: BTreeMap::new(),
+            session_map: AvlTreeMap::new(),
             session_list: Vec::new(),
             session_ids: Vec::new(),
         }


### PR DESCRIPTION
Despite use of unsafe code, the library is actively maintained and passes our fuzz tests. The size reduction seems worth it.